### PR TITLE
pop instead of del to prevent keyerror

### DIFF
--- a/lib/GenericsAPI/Utils/AttributeUtils.py
+++ b/lib/GenericsAPI/Utils/AttributeUtils.py
@@ -456,7 +456,7 @@ class AttributesUtil:
             attribute['attribute_ont_ref'] = ont_info['ontology_ref']
             attribute['attribute_ont_id'] = ont_info['id']
         elif not attribute.get('attribute_ont_id') or attribute['attribute_ont_id'] == ":":
-            del attribute['attribute_ont_id']
+            attribute.pop('attribute_ont_id', None)
 
         if attribute.get('unit'):
             ont_info = self._search_ontologies(attribute.get('unit_ont_id', '').replace("_", ":"))
@@ -464,7 +464,7 @@ class AttributesUtil:
                 attribute['unit_ont_ref'] = ont_info['ontology_ref']
                 attribute['unit_ont_id'] = ont_info['id']
             elif not attribute.get('attribute_ont_id') or attribute['unit_ont_id'] == ":":
-                del attribute['unit_ont_id']
+                attribute.pop('unit_ont_id', None)
 
         return attribute
 


### PR DESCRIPTION
KeyError is raise if attribute_ont_id and unit_ont_id don't exist in input
<img width="887" alt="Screen Shot 2019-04-02 at 8 30 29 PM" src="https://user-images.githubusercontent.com/124383/55446417-97615980-558d-11e9-80c7-faac8df1adad.png">
<img width="879" alt="Screen Shot 2019-04-02 at 8 30 42 PM" src="https://user-images.githubusercontent.com/124383/55446418-97615980-558d-11e9-9342-d1d73aa595ab.png">

